### PR TITLE
0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_
 - [ ] More verbose output
 - [ ] Proper benchmarks
 - [ ] Output fasta format (for blast??)
-- [ ] Output non gz (might be faster?)
+- [x] Output non `gz`
 
 ## Version
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_
 -r, --report <REPORT_OUTPUT>            
 -f, --fastq <FASTQ_FILE>              
 -o, --output <OUTPUT_LOCATION>            
---compression <COMPRESSION>      [default: default]
+--compression <COMPRESSION>      [default: fast]         
 --parents                    
 --children                   
--h, --help                       Print help
--V, --version                    Print version
+--no-compress                
+--exclude                    
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 `--parents`: This will extract all the reads classified at all taxons between the root and the specified `--taxid`

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ I recently wanted to extract reads from a large-ish (6GB) FASTQ file (~5.5 milli
 
 This is currently an early implementation (and my first Rust programme!), with plans to expand functionality.
 
-## Current features:
+## Current features
 
 - Extract all reads from a `fastq` file based on a taxonomic id
 - Extract parents or the children of the specified taxon id
 - Supports both uncompressed or `gzip` inputs.
 - Multithreaded
-- ~ 300% speed up over KrakenTools 
+- ~ 300% speed up over KrakenTools  
 
-### Benchmarks (rough):
+### Benchmarks (rough)
 
 Based on 6.1Gb fastq.gz with 5,454,495 reads | 1.8Gb kraken output - 
 
@@ -37,11 +37,13 @@ Time to parse the kraken output, extract all matching reads, and write to new fa
 ## Installation
 
 Clone the repository:
-```
+
+```bash
 git clone https://github.com/Sam-Sims/kraken-extract
 ```
 
 Build from source:
+
 ```bash
 cd kraken-extract
 cargo build --release
@@ -52,11 +54,12 @@ All executables will be in the directory kraken-extract/target/release.
 
 ## Usage
 
-```
+```bash
 kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_id> --output <output_file>
 ```
 
 ## Arguments
+
 ```
 -k, --kraken <KRAKEN_OUTPUT>            
 -t, --taxid <TAXID>              
@@ -77,6 +80,7 @@ kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_
 `--compression`: This defines the compression mode of the output `fastq.gz` file - fast / default / best
 
 ## Future plans
+
 - [x] Support unzipped fastq files
 - [ ] Support paired end FASTQ files
 - [x] `--include-parents` and `--include-children` arguments
@@ -87,23 +91,25 @@ kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_
 - [ ] More verbose output
 - [ ] Proper benchmarks
 - [ ] Output fasta format (for blast??)
-
+- [ ] Output non gz (might be faster?)
 
 ## Version
+
 - 0.2.1
 
 ## Changelog
 
-### 0.2.1:
-- Fixes to reduce memory usage
-    - Buffread the kraken output
-    - Dont assign line bytes before writing to output
+### 0.2.1
 
-### 0.2.0:
+- Fixes to reduce memory usage
+
+### 0.2.0
+
 - Detect and handle `gz` files or plain files
 - `--compression` arg to select compression type
 - `zlib-ng` to speed up gzip handling
 - `--children` and `--parents` to save children and parents based on kraken report
 
-### 0.1.0:
+### 0.1.0
+
 - First release

--- a/README.md
+++ b/README.md
@@ -79,19 +79,24 @@ kraken-extract --kraken <kraken_output> --fastq <fastq_file> --taxid <taxonomic_
 
 `--compression`: This defines the compression mode of the output `fastq.gz` file - fast / default / best
 
+`--no-compress`: This will output a plaintext `fastq` file
+
+`--exclude`: This will output every read except those matching the taxid. Works with `--parents` and `--children`
+
 ## Future plans
 
 - [x] Support unzipped fastq files
 - [ ] Support paired end FASTQ files
 - [x] `--include-parents` and `--include-children` arguments
 - [ ] Supply multiple taxonomic IDs to extract
-- [ ] Exclude taxonomic IDs
+- [x] Exclude taxonomic IDs
 - [ ] `--append`
 - [x] `--compression-mode <fast/default/best>`
-- [ ] More verbose output
+- [x] More verbose output
 - [ ] Proper benchmarks
 - [ ] Output fasta format (for blast??)
 - [x] Output non `gz`
+- [ ] Tests
 
 ## Version
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ struct Args {
     children: bool,
     #[arg(long)]
     no_compress: bool,
+    #[arg(long)]
+    exclude: bool,
 }
 
 /// Reads a FASTQ file from the specified path and returns a buffered reader.
@@ -331,13 +333,19 @@ fn main() {
     for line_result in reader.lines() {
         let line = line_result.expect("Error reading kraken output line");
         let (taxon_id, read_id) = process_kraken_output_line(&line);
-        if taxon_ids_to_save.contains(&taxon_id) {
-            reads_to_save.insert(read_id.clone(), taxon_id);
+        if args.exclude {
+            if !taxon_ids_to_save.contains(&taxon_id) {
+                reads_to_save.insert(read_id.clone(), taxon_id);
+            }
+        } else {
+            if taxon_ids_to_save.contains(&taxon_id) {
+                reads_to_save.insert(read_id.clone(), taxon_id);
+            }
         }
         total_reads += 1;
     }
     println!("Done!");
-    println!("{} taxon IDs to save", taxon_ids_to_save.len());
+    println!("{} taxon IDs identified", taxon_ids_to_save.len());
     println!(
         "{} total reads | {} reads to save.",
         total_reads,


### PR DESCRIPTION
# 0.2.2
- Increased verbosity of outputs to user
- `--no-compress` flag to output a standard, plaintext fastq file
- `--exclude` to exclude specified reads. Works with `--children` and `--parents`
- Docstrings under the hood