### PR TITLE
Dev/2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] - 2025-08-12
 
 ### Added
-- Added a reads extracted per taxon field to to summary report (#28)
-- Added a proportion extracted field to summary report (#28)
-- Added kractor version to summary report (#28)
+- Added a `reads_extracted_per_taxon` field to to summary report (#28)
+- Added a `proportion_extracted` field to summary report (#28)
+- Added the version to summary report (#28)
 - Added an output format (`fasta` or `fastq`) field to the summary report (#28)
 - Added a `--verbose` flag (in addition to the existing `-v`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-12
+
+### Added
+- Added a reads extracted per taxon field to to summary report (#28)
+- Added a proportion extracted field to summary report (#28)
+- Added kractor version to summary report (#28)
+- Added an output format (`fasta` or `fastq`) field to the summary report (#28)
+- Added a `--verbose` flag (in addition to the existing `-v`)
+
+### Changed
+- Removed `-O` for compression type, now uses `--compression-format` for clarity.
+- Removed `-l` for compression level, now uses `--compression-level` for clarity.
+- Renamed `--json-report` to `--summary`
+- Improved the JSON report format to make it easier to read by removing `Paired` and `Single` fields and instead having a simple `total_reads_in` and `total_reads_out` field.
+
+### Fixed
+- Removed duplicate log message for taxon IDs identified
+- Clippy warnings
+
 ## [1.0.1] - 2025-06-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "kractor"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "bzip2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kractor"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 authors = ["Samuel Sims"]
 description = "Extract reads from a FASTQ file based on taxonomic classification via Kraken2."

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Use `--json-report` to get summary statistics (output to stdout on completion)
   "proportion_extracted": 0.2140419091180432,
   "input_format": "single",
   "output_format": "fastq",
-  "kractor_version": "1.0.1"
+  "kractor_version": "2.0.0"
 }
 ```
 
@@ -177,8 +177,6 @@ Paired end reads can be specified by:
 Using `--input` twice: `-i <R1_fastq_file> -i <R2_fastq_file>`
 
 Using `--input` once but passing both files: `-i <R1_fastq_file> <R2_fastq_file>`
-
-This means that bash wildcard expansion works: `-i *.fastq`
 
 #### Output
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -180,7 +180,6 @@ pub fn collect_taxons_to_save(
     taxon_ids_to_save.sort_unstable();
     taxon_ids_to_save.dedup();
 
-    debug!("Taxon IDs identified: {:?}", taxon_ids_to_save);
     if taxon_ids_to_save.is_empty() {
         bail!("No taxon IDs were identified for extraction");
     }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -26,11 +26,14 @@ pub fn process_single_end(
 
         let writer = scope.spawn(|_| {
             if fasta {
-                write_output_fasta(rx, &output[0])
-                    .wrap_err_with(|| format!("Failed to write output file: {}", output[0].display()))
+                write_output_fasta(rx, &output[0]).wrap_err_with(|| {
+                    format!("Failed to write output file: {}", output[0].display())
+                })
             } else {
                 write_output_fastq(rx, &output[0], compression_type, compression_level)
-                    .wrap_err_with(|| format!("Failed to write output file: {}", output[0].display()))
+                    .wrap_err_with(|| {
+                        format!("Failed to write output file: {}", output[0].display())
+                    })
             }
         });
 
@@ -60,13 +63,17 @@ pub fn process_paired_end(
         let reader1 = scope.spawn(|_| {
             let result = parse_fastq(&input[0], reads_to_save, &tx1);
             drop(tx1);
-            result.wrap_err_with(|| format!("Failed to parse first input file: {}", input[0].display()))
+            result.wrap_err_with(|| {
+                format!("Failed to parse first input file: {}", input[0].display())
+            })
         });
 
         let reader2 = scope.spawn(|_| {
             let result = parse_fastq(&input[1], reads_to_save, &tx2);
             drop(tx2);
-            result.wrap_err_with(|| format!("Failed to parse second input file: {}", input[1].display()))
+            result.wrap_err_with(|| {
+                format!("Failed to parse second input file: {}", input[1].display())
+            })
         });
 
         let writer1 = scope.spawn(|_| {
@@ -397,7 +404,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![1239];
-        let saved_taxons = collect_taxons_to_save(&Some(report_path), true, false, &taxids).unwrap();
+        let saved_taxons =
+            collect_taxons_to_save(&Some(report_path), true, false, &taxids).unwrap();
 
         assert!(saved_taxons.contains(&1239));
         assert!(saved_taxons.contains(&91062));
@@ -409,7 +417,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![91061];
-        let saved_taxons = collect_taxons_to_save(&Some(report_path), false, true, &taxids).unwrap();
+        let saved_taxons =
+            collect_taxons_to_save(&Some(report_path), false, true, &taxids).unwrap();
 
         assert!(saved_taxons.contains(&91061));
         assert!(saved_taxons.contains(&1239));

--- a/src/kractor.rs
+++ b/src/kractor.rs
@@ -53,7 +53,7 @@ impl Kractor {
             &self.args.report,
             self.args.children,
             self.args.parents,
-            self.args.taxid.clone(),
+            &self.args.taxid,
         )?;
         debug!("Taxon IDs identified: {:?}", self.taxon_ids);
         Ok(())
@@ -139,7 +139,7 @@ impl Kractor {
         if let Some(summary) = &self.summary {
             if self.args.summary {
                 let json = serde_json::to_string_pretty(summary)?;
-                println!("{}", json);
+                println!("{json}");
             }
         }
         Ok(())

--- a/src/kractor.rs
+++ b/src/kractor.rs
@@ -137,7 +137,7 @@ impl Kractor {
 
     fn output_summary(&self) -> Result<()> {
         if let Some(summary) = &self.summary {
-            if self.args.json {
+            if self.args.summary {
                 let json = serde_json::to_string_pretty(summary)?;
                 println!("{}", json);
             }
@@ -187,7 +187,7 @@ mod tests {
             children: false,
             exclude: false,
             output_fasta: false,
-            json: false,
+            summary: false,
             verbose: false,
         };
         let kractor = Kractor::new(args);
@@ -212,7 +212,7 @@ mod tests {
             children: false,
             exclude: false,
             output_fasta: false,
-            json: false,
+            summary: false,
             verbose: false,
         };
         let kractor = Kractor::new(args);

--- a/src/kractor.rs
+++ b/src/kractor.rs
@@ -2,35 +2,27 @@ use crate::extract::{process_paired_end, process_single_end};
 use crate::{extract, parsers, Cli};
 use color_eyre::eyre::ensure;
 use color_eyre::Result;
-use fxhash::FxHashSet;
+use fxhash::{FxHashMap, FxHashSet};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct Summary {
-    taxon_count: usize,
-    taxon_ids: Vec<i32>,
-    reads_in: ReadCounts,
-    reads_out: ReadCounts,
+    total_taxon_count: usize,
+    reads_extracted_per_taxon: FxHashMap<i32, usize>,
+    total_reads_in: usize,
+    total_reads_out: usize,
+    proportion_extracted: f64,
     input_format: String,
-}
-
-#[derive(Serialize, Deserialize)]
-enum ReadCounts {
-    Single {
-        total: usize,
-    },
-    Paired {
-        total: usize,
-        read1: usize,
-        read2: usize,
-    },
+    output_format: String,
+    kractor_version: String,
 }
 
 pub struct Kractor {
     args: Cli,
     taxon_ids: Vec<i32>,
     reads_to_save: FxHashSet<Vec<u8>>,
+    reads_per_taxon: FxHashMap<i32, usize>,
     summary: Option<Summary>,
 }
 
@@ -40,6 +32,7 @@ impl Kractor {
             args,
             taxon_ids: Vec::new(),
             reads_to_save: FxHashSet::default(),
+            reads_per_taxon: FxHashMap::default(),
             summary: None,
         }
     }
@@ -67,7 +60,7 @@ impl Kractor {
     }
 
     fn process_kraken_output(&mut self) -> Result<()> {
-        self.reads_to_save = parsers::kraken::process_kraken_output(
+        (self.reads_to_save, self.reads_per_taxon) = parsers::kraken::process_kraken_output(
             &self.args.kraken,
             self.args.exclude,
             &self.taxon_ids,
@@ -92,24 +85,23 @@ impl Kractor {
                     self.args.output_fasta,
                 )?;
 
-            let reads_in = ReadCounts::Paired {
-                total: reads_parsed1 + reads_parsed2,
-                read1: reads_parsed1,
-                read2: reads_parsed2,
-            };
+            let reads_in = reads_parsed1 + reads_parsed2;
 
-            let reads_out = ReadCounts::Paired {
-                total: reads_output1 + reads_output2,
-                read1: reads_output1,
-                read2: reads_output2,
-            };
+            let reads_out = reads_output1 + reads_output2;
 
             self.summary = Some(Summary {
-                taxon_count: self.taxon_ids.len(),
-                taxon_ids: self.taxon_ids.clone(),
-                reads_in,
-                reads_out,
+                total_taxon_count: self.taxon_ids.len(),
+                reads_extracted_per_taxon: self.reads_per_taxon.clone(),
+                total_reads_in: reads_in,
+                total_reads_out: reads_out,
+                proportion_extracted: reads_out as f64 / reads_in as f64,
                 input_format: input_format.to_string(),
+                output_format: if self.args.output_fasta {
+                    "fasta".to_string()
+                } else {
+                    "fastq".to_string()
+                },
+                kractor_version: env!("CARGO_PKG_VERSION").to_string(),
             });
         } else {
             let (reads_parsed1, reads_output1) = process_single_end(
@@ -121,19 +113,22 @@ impl Kractor {
                 self.args.output_fasta,
             )?;
 
-            let reads_in = ReadCounts::Single {
-                total: reads_parsed1,
-            };
-            let reads_out = ReadCounts::Single {
-                total: reads_output1,
-            };
+            let reads_in = reads_parsed1;
+            let reads_out = reads_output1;
 
             self.summary = Some(Summary {
-                taxon_count: self.taxon_ids.len(),
-                taxon_ids: self.taxon_ids.clone(),
-                reads_in,
-                reads_out,
+                total_taxon_count: self.taxon_ids.len(),
+                reads_extracted_per_taxon: self.reads_per_taxon.clone(),
+                total_reads_in: reads_in,
+                total_reads_out: reads_out,
+                proportion_extracted: reads_out as f64 / reads_in as f64,
                 input_format: input_format.to_string(),
+                output_format: if self.args.output_fasta {
+                    "fasta".to_string()
+                } else {
+                    "fastq".to_string()
+                },
+                kractor_version: env!("CARGO_PKG_VERSION").to_string(),
             });
         }
 

--- a/src/parsers/fastx.rs
+++ b/src/parsers/fastx.rs
@@ -14,23 +14,23 @@ pub fn parse_fastq(
     reads_to_save: &FxHashSet<Vec<u8>>,
     tx: &Sender<fastq::Record>,
 ) -> Result<usize> {
-    let mut num_reads = 0;
-
-    let mut last_progress_update = Instant::now();
     const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(1500);
+    
+    let mut num_reads = 0;
+    let mut last_progress_update = Instant::now();
 
     let (reader, format) = niffler::from_path(file_path)
-        .wrap_err_with(|| format!("Failed to open fastq file: {:?}", file_path))?;
+        .wrap_err_with(|| format!("Failed to open fastq file: {}", file_path.display()))?;
     debug!(
-        "Detected input compression type for file {:?} as: {:?}",
-        file_path, format
+        "Detected input compression type for file {} as: {format:?}",
+        file_path.display()
     );
     let reader = BufReader::new(reader);
     let mut fastq_reader = fastq::Reader::new(reader);
 
     for (record_idx, result) in fastq_reader.records().enumerate() {
         let record = result
-            .wrap_err_with(|| format!("Error reading FASTQ record at position {}", record_idx))?;
+            .wrap_err_with(|| format!("Error reading FASTQ record at position {record_idx}"))?;
 
         let read_id = record.name();
         if reads_to_save.contains(&read_id.to_vec()) {
@@ -39,7 +39,7 @@ pub fn parse_fastq(
         num_reads += 1;
 
         if last_progress_update.elapsed() >= PROGRESS_UPDATE_INTERVAL {
-            trace!("Processed {} reads", num_reads);
+            trace!("Processed {num_reads} reads");
             last_progress_update = Instant::now();
         }
     }
@@ -64,29 +64,23 @@ pub fn write_output_fastq(
     compression_level: niffler::Level,
 ) -> Result<usize> {
     let mut read_output_count = 0;
-    let compression_type = match output_type {
-        Some(output_type) => {
-            debug!("Output type overridden as: {:?}", output_type);
-            output_type
-        }
-        None => {
-            let inferred_type = infer_compression(out_file);
-            debug!("Inferred output compression type as: {:?}", inferred_type);
-            inferred_type
-        }
+    let compression_type = if let Some(output_type) = output_type {
+        debug!("Output type overridden as: {output_type:?}");
+        output_type
+    } else {
+        let inferred_type = infer_compression(out_file);
+        debug!("Inferred output compression type as: {inferred_type:?}");
+        inferred_type
     };
 
-    debug!(
-        "Output compression level specified as: {:?}",
-        compression_level
-    );
-    debug!("Creating output file: {:?}", out_file);
+    debug!("Output compression level specified as: {compression_level:?}");
+    debug!("Creating output file: {}", out_file.display());
 
     fs::create_dir_all(out_file.parent().unwrap())
-        .wrap_err_with(|| format!("Failed to create output directory: {out_file:?}"))?;
+        .wrap_err_with(|| format!("Failed to create output directory: {}", out_file.display()))?;
 
     let out_file = fs::File::create(out_file)
-        .wrap_err_with(|| format!("Failed to create output file: {out_file:?}"))?;
+        .wrap_err_with(|| format!("Failed to create output file: {}", out_file.display()))?;
 
     let file_handle = Box::new(io::BufWriter::new(out_file));
     let writer = niffler::get_writer(file_handle, compression_type, compression_level)
@@ -97,7 +91,7 @@ pub fn write_output_fastq(
     for record in rx {
         fastq_writer
             .write_record(&record)
-            .wrap_err_with(|| format!("Error writing FASTQ record: {:?}", record))?;
+            .wrap_err_with(|| format!("Error writing FASTQ record: {record:?}"))?;
         read_output_count += 1;
     }
 
@@ -105,10 +99,10 @@ pub fn write_output_fastq(
 }
 
 pub fn write_output_fasta(rx: Receiver<fastq::Record>, out_file: &PathBuf) -> Result<usize> {
-    debug!("Creating output file: {:?}", out_file);
+    debug!("Creating output file: {}", out_file.display());
     let mut total_read_count = 0;
     let out_file = fs::File::create(out_file)
-        .wrap_err_with(|| format!("Failed to create output file: {:?}", out_file))?;
+        .wrap_err_with(|| format!("Failed to create output file: {}", out_file.display()))?;
 
     let mut writer = fasta::Writer::new(out_file);
 
@@ -124,7 +118,7 @@ pub fn write_output_fasta(rx: Receiver<fastq::Record>, out_file: &PathBuf) -> Re
 
         writer
             .write_record(&fasta::Record::new(definition, sequence))
-            .wrap_err_with(|| format!("Error writing FASTA record: {:?}", record))?;
+            .wrap_err_with(|| format!("Error writing FASTA record: {record:?}"))?;
         total_read_count += 1;
     }
 

--- a/src/parsers/fastx.rs
+++ b/src/parsers/fastx.rs
@@ -15,7 +15,7 @@ pub fn parse_fastq(
     tx: &Sender<fastq::Record>,
 ) -> Result<usize> {
     const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(1500);
-    
+
     let mut num_reads = 0;
     let mut last_progress_update = Instant::now();
 

--- a/src/parsers/kraken.rs
+++ b/src/parsers/kraken.rs
@@ -90,8 +90,12 @@ pub fn process_kraken_output(
     let taxon_ids_to_save: HashSet<i32> = taxon_ids_to_save.iter().copied().collect();
     let mut reads_per_taxon: FxHashMap<i32, usize> = FxHashMap::default();
     let mut reads_to_save = FxHashSet::default();
-    let kraken_file = fs::File::open(kraken_path)
-        .wrap_err_with(|| format!("Failed to open kraken output file: {}", kraken_path.display()))?;
+    let kraken_file = fs::File::open(kraken_path).wrap_err_with(|| {
+        format!(
+            "Failed to open kraken output file: {}",
+            kraken_path.display()
+        )
+    })?;
     let reader = BufReader::new(kraken_file);
 
     for line_result in reader.lines() {
@@ -179,8 +183,12 @@ pub fn build_tree_from_kraken_report(
     // taxonid -> index in the nodes vector
     let mut taxon_map = HashMap::new();
 
-    let report_file = fs::File::open(report_path)
-        .wrap_err_with(|| format!("Failed to open kraken report file: {}", report_path.display()))?;
+    let report_file = fs::File::open(report_path).wrap_err_with(|| {
+        format!(
+            "Failed to open kraken report file: {}",
+            report_path.display()
+        )
+    })?;
 
     let reader = BufReader::new(report_file);
     let mut prev_index = None;

--- a/src/parsers/kraken.rs
+++ b/src/parsers/kraken.rs
@@ -82,6 +82,7 @@ fn process_kraken_output_line(kraken_output: &str) -> Result<KrakenRecord> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn process_kraken_output(
     kraken_path: &PathBuf,
     exclude: bool,


### PR DESCRIPTION
## [2.0.0] - 2025-08-12

### Added
- Added a `reads_extracted_per_taxon` field to to summary report (#28)
- Added a `proportion_extracted` field to summary report (#28)
- Added the version to summary report (#28)
- Added an output format (`fasta` or `fastq`) field to the summary report (#28)
- Added a `--verbose` flag (in addition to the existing `-v`)

### Changed
- Removed `-O` for compression type, now uses `--compression-format` for clarity.
- Removed `-l` for compression level, now uses `--compression-level` for clarity.
- Renamed `--json-report` to `--summary`
- Improved the JSON report format to make it easier to read by removing `Paired` and `Single` fields and instead having a simple `total_reads_in` and `total_reads_out` field.

### Fixed
- Removed duplicate log message for taxon IDs identified
- Clippy warnings