### PR TITLE
feat/report header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2025-12-12
+
+### Added
+
+- Attempt to detect headers in kraken report files and skip if it looks like a header. It does this by checking if there
+  are 6 fields that are all strings (or more precisely if each field returns an error when parsing into an int/float).
+  If so,
+  it is assumed that this line is a header and is skipped. A warning message is printed in this case.
+- `--no-header-detect` flag to force parsing Kraken reports from the first line without auto-skipping headers, disabling
+  the new header detection behaviour described above
+
+### Changed
+
+- Kraken report/output parsing errors now include the line number and o line for easier debugging.
+
 ## [3.0.1] - 2025-10-16
 
 ### Fixed
+
 - Prevent a panic when writing to output paths without an extension.
 
 ## [3.0.0] - 2025-09-26
 
 ### Added
-- Able to specifiy taxon ids that are not present, without kractor stopping. These are instead logged to stderr with a warning. This may be useful when running kractor in a wrapper script for several fastq files and just want to extract a set of taxonids from them all - without caring if they are present or not.
+
+- Able to specifiy taxon ids that are not present, without kractor stopping. These are instead logged to stderr with a
+  warning. This may be useful when running kractor in a wrapper script for several fastq files and just want to extract
+  a set of taxonids from them all - without caring if they are present or not.
 - Include a new field `missing_taxon_ids` in the summary output.
 
 ### Changed
-- Under the hood refactoring, introducing structs for the processed kraken outputs and processed kraken trees to simplify the returned data.
+
+- Under the hood refactoring, introducing structs for the processed kraken outputs and processed kraken trees to
+  simplify the returned data.
 
 ### Fixed
-- Unclassified reads being skipped in the tree building stage, meaning they were unable to be extracted 
+
+- Unclassified reads being skipped in the tree building stage, meaning they were unable to be extracted
 
 ## [2.0.0] - 2025-08-12
 
 ### Added
+
 - Added a `reads_extracted_per_taxon` field to to summary report (#28)
 - Added a `proportion_extracted` field to summary report (#28)
 - Added the version to summary report (#28)
@@ -32,91 +55,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `--verbose` flag (in addition to the existing `-v`)
 
 ### Changed
+
 - Removed `-O` for compression type, now uses `--compression-format` for clarity.
 - Removed `-l` for compression level, now uses `--compression-level` for clarity.
 - Renamed `--json-report` to `--summary`
-- Improved the JSON report format to make it easier to read by removing `Paired` and `Single` fields and instead having a simple `total_reads_in` and `total_reads_out` field.
+- Improved the JSON report format to make it easier to read by removing `Paired` and `Single` fields and instead having
+  a simple `total_reads_in` and `total_reads_out` field.
 
 ### Fixed
+
 - Removed duplicate log message for taxon IDs identified
 - Clippy warnings
 
 ## [1.0.1] - 2025-06-28
 
 ### Fixed
+
 - Create subdirectories specified in output path if they don't exist (#24)
 - Add output validation to prevent overwriting existing files (#25)
 
 ## [1.0.0] - 2025-04-16
 
 ### Added
+
 - Better error handling with color-eyre (#16)
 - Proper panic handling (#16)
 - Tests for most functions
 - JSON report with accurate read count information (#15)
 
 ### Changed
+
 - Keep fastq parsing in bytes instead of converting to String (#17)
 - Optimized functions to take `&str` instead of `String` (#21)
 - Migrated to crossbeam scoped channels and refactored threading code
 - Refactored JSON output and removed lazy_static dependency
 
 ### Fixed
+
 - Root node no longer added to tree twice (#22)
 
 ## [0.4.0] - 2023-10-06
 
 ### Added
+
 - JSON report included in stdout upon successful completion (can be disabled with `--no-json`)
 
 ### Changed
+
 - Project renamed
 
 ## [0.3.0] - 2023-09-22
 
 ### Added
+
 - Support for paired-end files
 - Output FASTA file with `--output-fasta` option
 
 ### Changed
+
 - Major refactor to use Noodles for fastq parsing
 - Switched to Niffler for compression handling
 - Streamlined arguments related to compression types/level
 
 ### Improved
+
 - Logging functionality
 
 ## [0.2.3] - 2023-09-02
 
 ### Changed
+
 - Code optimizations
 
 ## [0.2.2]
 
 ### Added
+
 - `--no-compress` flag to output standard plaintext fastq files
 - `--exclude` option to exclude specified reads (works with `--children` and `--parents`)
 - Internal documentation (docstrings)
 
 ### Improved
+
 - Increased verbosity of user outputs
 
 ## [0.2.1]
 
 ### Fixed
+
 - Reduced memory usage
 
 ## [0.2.0]
 
 ### Added
+
 - Automatic detection and handling of gz and plain files
 - `--compression` argument to select compression type
 - `--children` and `--parents` options to save children and parents based on kraken report
 
 ### Changed
+
 - Integrated zlib-ng for faster gzip handling
 
 ## [0.1.0]
 
 ### Added
+
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "kractor"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "bzip2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kractor"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 authors = ["Samuel Sims"]
 description = "Extract reads from a FASTQ file based on taxonomic classification via Kraken2."

--- a/README.md
+++ b/README.md
@@ -10,25 +10,29 @@
 
 **kra**ken extr**actor**
 
-Kractor extracts reads from fastq `[.gz/.bz2]` files using taxonomic classifications obtained via Kraken2. 
-It supports single or paired-end reads, can optionally include taxonomic parents or children, and uses minimal memory (~4.5 MB for a 17 GB FASTQ file).
+Kractor extracts reads from fastq `[.gz/.bz2]` files using taxonomic classifications obtained via Kraken2.
+It supports single or paired-end reads, can optionally include taxonomic parents or children, and uses minimal memory (~
+4.5 MB for a 17 GB FASTQ file).
 
 The end result is a `fast[q/a]` file containing all reads classified as the specified taxon(s).
 
 Kractor significantly enhances processing speed compared to KrakenTools for both paired and unpaired reads.
 
 Performance vs KrakenTools:
-- Paired compressed FASTQ: ~21× faster 
-- Paired uncompressed FASTQ: ~10× faster 
+
+- Paired compressed FASTQ: ~21× faster
+- Paired uncompressed FASTQ: ~10× faster
 - Unpaired: ~4× faster (compressed or uncompressed)
 
 For additional details, refer to the [benchmarks](benchmarks/benchmarks.md)
 
 ## Motivation
 
-Provides similar functionality to the [KrakenTools](https://github.com/jenniferlu717/KrakenTools) `extract_kraken_reads` python script.
+Provides similar functionality to the [KrakenTools](https://github.com/jenniferlu717/KrakenTools) `extract_kraken_reads`
+python script.
 
-However the main motivation was to enhance speed when processing multiple, large FASTQ files - and as a way to learn Rust.
+However the main motivation was to enhance speed when processing multiple, large FASTQ files - and as a way to learn
+Rust.
 
 ## Installation
 
@@ -115,6 +119,8 @@ Options:
           Output results in FASTA format
       --summary
           Enable a JSON summary output written to stdout
+      --no-header-detect
+          Disable detection and skipping of header lines in the Kraken2 report
   -v, --verbose
           Enable verbose output
   -h, --help
@@ -146,7 +152,9 @@ kractor -i sample.fastq -o extracted.fasta -k kraken_output.txt -t 562 --output-
 ```
 
 ### Summary statistics
+
 Use `--summary` to get summary statistics (output to stdout on completion)
+
 ```json
 {
   "total_taxon_count": 2,
@@ -162,7 +170,7 @@ Use `--summary` to get summary statistics (output to stdout on completion)
   "proportion_extracted": 0.2140419091180432,
   "input_format": "single",
   "output_format": "fastq",
-  "kractor_version": "2.0.0"
+  "kractor_version": "3.1.0"
 }
 ```
 
@@ -174,7 +182,7 @@ Use `--summary` to get summary statistics (output to stdout on completion)
 
 `-i, --input`
 
-Specifies one or two input FASTQ files to extract reads from. Files may be uncompressed or compressed (`gz`, `bz2`). 
+Specifies one or two input FASTQ files to extract reads from. Files may be uncompressed or compressed (`gz`, `bz2`).
 Paired end reads can be specified by:
 
 Using `--input` twice: `-i <R1_fastq_file> -i <R2_fastq_file>`
@@ -185,26 +193,30 @@ Using `--input` once but passing both files: `-i <R1_fastq_file> <R2_fastq_file>
 
 `-o, --output`
 
-Specifies the output file(s) for extracted reads, matching the order of the input files. 
+Specifies the output file(s) for extracted reads, matching the order of the input files.
 Compression type is inferred from the file extension (.gz, .bz2). If not recognised, output will be uncompressed.
 
 #### Kraken Output
 
 `-k, --kraken`
 
-Path to the [Standard Kraken Output Format file](https://github.com/DerrickWood/kraken2/wiki/Manual#standard-kraken-output-format), containing taxonomic classification of read IDs.
+Path to
+the [Standard Kraken Output Format file](https://github.com/DerrickWood/kraken2/wiki/Manual#standard-kraken-output-format),
+containing taxonomic classification of read IDs.
 
 #### Taxid
 
 `-t, --taxid`
 
-One or more taxonomic IDs to extract. 
+One or more taxonomic IDs to extract.
 
 For example: `-t 1 2 10`
 
 Each taxonomic id is affected by `--exclude`, `--parents`, and `--children` if those options are used.
 
-Taxonomic ids do not need to be present in a given report. This may be useful when running kractor in a wrapper script for several fastq files and just want to extract a set of taxon ids from them all - without caring if they are present or not.
+Taxonomic ids do not need to be present in a given report. This may be useful when running kractor in a wrapper script
+for several fastq files and just want to extract a set of taxon ids from them all - without caring if they are present
+or not.
 
 ### Optional:
 
@@ -212,20 +224,22 @@ Taxonomic ids do not need to be present in a given report. This may be useful wh
 
 `--compression-format`
 
-Manually set output compression format, overriding what is inferred from file names. 
+Manually set output compression format, overriding what is inferred from file names.
 
 Valid values:
-- `gz` – gzip compression 
-- `bz2` – bzip2 compression 
+
+- `gz` – gzip compression
+- `bz2` – bzip2 compression
 - `none` – no compression
 
 #### Compression level
 
 `--compression-level`
 
-Set compression level (1–9). 
-- 1 = fastest, largest file 
-- 9 = slowest, smallest file 
+Set compression level (1–9).
+
+- 1 = fastest, largest file
+- 9 = slowest, smallest file
 
 Default: 2 (balance of speed and size)
 
@@ -239,7 +253,12 @@ Output sequences in FASTA format instead of FASTQ.
 
 `-r, --report`
 
-Path to the [Kraken2 report file](https://github.com/DerrickWood/kraken2/wiki/Manual#sample-report-output-format). Required if using `--parents` or `--children`.
+Path to the [Kraken2 report file](https://github.com/DerrickWood/kraken2/wiki/Manual#sample-report-output-format).
+Required if using `--parents` or `--children`.
+
+The first line is automatically treated as a header if it looks non-numeric; use `--no-header-detect` to force parsing
+from the very first line. Parsing errors will include the report line number and offending line to help spot format
+issues.
 
 #### Parents
 
@@ -265,8 +284,10 @@ Extract all reads except those matching the given taxids. Can be combined with `
 
 Write a JSON report to stdout after processing.
 
-## Citation 
+## Citation
+
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15761837.svg)](https://doi.org/10.5281/zenodo.15761837)
+
 ```
 Sam Sims. (2025). Sam-Sims/kractor. Zenodo. https://doi.org/10.5281/zenodo.15761837
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,9 @@ pub struct Cli {
     /// Enable a JSON summary output written to stdout.
     #[arg(long = "summary")]
     pub summary: bool,
+    /// Disable detection and skipping of any header lines in the Kraken2 report.
+    #[arg(long = "no-header-detect", action)]
+    pub no_report_header_detect: bool,
     /// Enable verbose output.
     #[arg(short, long)]
     pub verbose: bool,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -147,6 +147,7 @@ pub fn collect_taxons_to_save(
     children: bool,
     parents: bool,
     taxids: &[i32],
+    detect_report_header: bool,
 ) -> Result<CollectedTaxonIds> {
     let mut taxon_ids_to_save = Vec::new();
     let mut missing_taxon_ids = Vec::new();
@@ -161,7 +162,7 @@ pub fn collect_taxons_to_save(
             nodes,
             taxon_map,
             missing_taxon_ids: missing_ids,
-        } = build_tree_from_kraken_report(taxids, report_path)
+        } = build_tree_from_kraken_report(taxids, report_path, detect_report_header)
             .wrap_err("Failed to build tree from Kraken report")?;
 
         if !missing_ids.is_empty() {
@@ -407,16 +408,16 @@ mod tests {
 
     #[test]
     fn test_error_when_no_report_and_parents_or_children() {
-        let result = collect_taxons_to_save(&None, true, false, &[1]);
+        let result = collect_taxons_to_save(&None, true, false, &[1], true);
         assert!(result.is_err());
-        let result = collect_taxons_to_save(&None, false, true, &[1]);
+        let result = collect_taxons_to_save(&None, false, true, &[1], true);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_no_report() {
         let taxids = vec![123, 456, 789];
-        let collected = collect_taxons_to_save(&None, false, false, &taxids).unwrap();
+        let collected = collect_taxons_to_save(&None, false, false, &taxids, true).unwrap();
 
         assert_eq!(collected.found, taxids);
         assert!(collected.missing.is_empty());
@@ -427,7 +428,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![0, 2];
-        let collected = collect_taxons_to_save(&Some(report_path), false, false, &taxids).unwrap();
+        let collected =
+            collect_taxons_to_save(&Some(report_path), false, false, &taxids, true).unwrap();
 
         assert_eq!(collected.found, vec![0, 2]);
         assert!(collected.missing.is_empty());
@@ -438,7 +440,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![1385, 1386, 91061];
-        let collected = collect_taxons_to_save(&Some(report_path), false, false, &taxids).unwrap();
+        let collected =
+            collect_taxons_to_save(&Some(report_path), false, false, &taxids, true).unwrap();
 
         assert_eq!(collected.found, taxids);
         assert!(collected.missing.is_empty());
@@ -449,7 +452,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![1239];
-        let collected = collect_taxons_to_save(&Some(report_path), true, false, &taxids).unwrap();
+        let collected =
+            collect_taxons_to_save(&Some(report_path), true, false, &taxids, true).unwrap();
 
         assert!(collected.found.contains(&1239));
         assert!(collected.found.contains(&91062));
@@ -461,7 +465,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![91061];
-        let collected = collect_taxons_to_save(&Some(report_path), false, true, &taxids).unwrap();
+        let collected =
+            collect_taxons_to_save(&Some(report_path), false, true, &taxids, true).unwrap();
 
         assert!(collected.found.contains(&91061));
         assert!(collected.found.contains(&1239));
@@ -475,7 +480,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![999];
-        let result = collect_taxons_to_save(&Some(report_path), true, false, &taxids);
+        let result = collect_taxons_to_save(&Some(report_path), true, false, &taxids, true);
 
         assert!(result.is_err());
     }
@@ -485,7 +490,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let report_path = create_test_kraken_report(&dir);
         let taxids = vec![1239, 999];
-        let collected = collect_taxons_to_save(&Some(report_path), false, false, &taxids).unwrap();
+        let collected =
+            collect_taxons_to_save(&Some(report_path), false, false, &taxids, true).unwrap();
 
         assert!(collected.found.contains(&1239));
         assert_eq!(collected.missing, vec![999]);
@@ -494,7 +500,7 @@ mod tests {
     #[test]
     fn test_dedup_and_sort() {
         let taxids = vec![456, 123, 456, 789, 123];
-        let collected = collect_taxons_to_save(&None, false, false, &taxids).unwrap();
+        let collected = collect_taxons_to_save(&None, false, false, &taxids, true).unwrap();
 
         assert_eq!(collected.found, vec![123, 456, 789]);
         assert!(collected.missing.is_empty());
@@ -502,7 +508,7 @@ mod tests {
 
     #[test]
     fn test_empty_result() {
-        let result = collect_taxons_to_save(&None, false, false, &[]);
+        let result = collect_taxons_to_save(&None, false, false, &[], true);
 
         assert!(result.is_err());
     }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -162,8 +162,7 @@ pub fn collect_taxons_to_save(
             nodes,
             taxon_map,
             missing_taxon_ids: missing_ids,
-        } = build_tree_from_kraken_report(taxids, report_path, detect_report_header)
-            .wrap_err("Failed to build tree from Kraken report")?;
+        } = build_tree_from_kraken_report(taxids, report_path, detect_report_header)?;
 
         if !missing_ids.is_empty() {
             warn!(

--- a/src/kractor.rs
+++ b/src/kractor.rs
@@ -58,6 +58,7 @@ impl Kractor {
             self.args.children,
             self.args.parents,
             &self.args.taxid,
+            !self.args.no_report_header_detect,
         )?;
         self.taxon_ids = collected.found;
         self.missing_taxon_ids = collected.missing;
@@ -203,6 +204,7 @@ mod tests {
             exclude: false,
             output_fasta: false,
             summary: false,
+            no_report_header_detect: false,
             verbose: false,
         };
         let kractor = Kractor::new(args);
@@ -228,6 +230,7 @@ mod tests {
             exclude: false,
             output_fasta: false,
             summary: false,
+            no_report_header_detect: false,
             verbose: false,
         };
         let kractor = Kractor::new(args);

--- a/src/parsers/kraken.rs
+++ b/src/parsers/kraken.rs
@@ -111,9 +111,13 @@ pub fn process_kraken_output(
     })?;
     let reader = BufReader::new(kraken_file);
 
-    for line_result in reader.lines() {
-        let line = line_result.wrap_err("Error reading kraken output line")?;
-        let record = process_kraken_output_line(&line)?;
+    for (line_number, line_result) in reader.lines().enumerate() {
+        let line_number = line_number + 1;
+        let line = line_result
+            .wrap_err_with(|| format!("Error reading kraken output line {line_number}"))?;
+        let record = process_kraken_output_line(&line).wrap_err_with(|| {
+            format!("Failed to parse kraken output at line {line_number}: {line}")
+        })?;
         if (exclude && !taxon_ids_to_save.contains(&record.taxon_id))
             || (!exclude && taxon_ids_to_save.contains(&record.taxon_id))
         {
@@ -189,7 +193,7 @@ fn process_kraken_report_line(kraken_report: &str) -> Result<KrakenReportRecord>
     }
 }
 
-fn should_skip_header_line(line: &str, err: &color_eyre::Report) -> bool {
+fn should_skip_header_line(line: &str) -> bool {
     let fields: Vec<&str> = line.split('\t').collect();
     if fields.len() != 6 {
         return false;
@@ -225,16 +229,19 @@ pub fn build_tree_from_kraken_report(
     let mut prev_index = None;
 
     for (line_number, line_result) in reader.lines().enumerate() {
-        let line =
-            line_result.wrap_err(format!("Error reading kraken report line {}", line_number))?;
+        let line_number = line_number + 1;
+        let line = line_result
+            .wrap_err_with(|| format!("Error reading kraken report line {line_number}"))?;
         let record = match process_kraken_report_line(&line) {
             Ok(record) => record,
             Err(err) => {
-                if detect_header && line_number == 0 && should_skip_header_line(&line, &err) {
+                if detect_header && line_number == 1 && should_skip_header_line(&line) {
                     warn!("The first line of the kraken report looks like a header and will be skipped. If you want to disable this behaviour use --no-header-detect");
                     continue;
                 }
-                return Err(err);
+                return Err(err).wrap_err_with(|| {
+                    format!("Failed to build tree from kraken report at line {line_number}: {line}")
+                });
             }
         };
         if record.level == 0 {

--- a/src/parsers/kraken.rs
+++ b/src/parsers/kraken.rs
@@ -1,6 +1,6 @@
 use color_eyre::{eyre::bail, eyre::eyre, eyre::Context, Result};
 use fxhash::{FxHashMap, FxHashSet};
-use log::info;
+use log::{info, warn};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -189,9 +189,24 @@ fn process_kraken_report_line(kraken_report: &str) -> Result<KrakenReportRecord>
     }
 }
 
+fn should_skip_header_line(line: &str, err: &color_eyre::Report) -> bool {
+    let fields: Vec<&str> = line.split('\t').collect();
+    if fields.len() != 6 {
+        return false;
+    }
+
+    let all_string = fields.iter().all(|field| {
+        let trimmed = field.trim();
+        trimmed.is_empty() || (trimmed.parse::<f32>().is_err() && trimmed.parse::<i32>().is_err())
+    });
+
+    all_string
+}
+
 pub fn build_tree_from_kraken_report(
     taxon_to_save: &[i32],
     report_path: &PathBuf,
+    detect_header: bool,
 ) -> Result<ProcessedKrakenTree> {
     info!("Building taxonomic tree from kraken report");
     // will store the tree
@@ -209,9 +224,19 @@ pub fn build_tree_from_kraken_report(
     let reader = BufReader::new(report_file);
     let mut prev_index = None;
 
-    for line in reader.lines() {
-        let line = line.wrap_err("Error reading kraken report line")?;
-        let record = process_kraken_report_line(&line)?;
+    for (line_number, line_result) in reader.lines().enumerate() {
+        let line =
+            line_result.wrap_err(format!("Error reading kraken report line {}", line_number))?;
+        let record = match process_kraken_report_line(&line) {
+            Ok(record) => record,
+            Err(err) => {
+                if detect_header && line_number == 0 && should_skip_header_line(&line, &err) {
+                    warn!("The first line of the kraken report looks like a header and will be skipped. If you want to disable this behaviour use --no-header-detect");
+                    continue;
+                }
+                return Err(err);
+            }
+        };
         if record.level == 0 {
             prev_index = None;
         }
@@ -566,6 +591,64 @@ mod tests {
         assert!(process_kraken_report_line(line).is_err());
     }
 
+    #[test]
+    fn test_process_kraken_report_header() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("kraken_report.txt");
+        let test_data = "\
+        percent\tclades\ttaxons\trank\ttaxid\tscientific name
+        100.00\t100\t100\tR\t1\troot
+        10.77\t100\t50\tS\t1337\t  Homo sapiens";
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(test_data.as_bytes()).unwrap();
+
+        let taxon_to_save = vec![1337];
+        let ProcessedKrakenTree {
+            nodes,
+            taxon_map,
+            missing_taxon_ids,
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].taxon_id, 1);
+        assert_eq!(nodes[0].level_num, 0);
+        assert_eq!(nodes[1].taxon_id, 1337);
+        assert_eq!(nodes[1].parent, Some(0));
+        assert_eq!(taxon_map[&1337], 1);
+        assert!(missing_taxon_ids.is_empty());
+    }
+
+    #[test]
+    fn test_process_kraken_report_header_disabled() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("kraken_report.txt");
+        let test_data = "\
+        percent\tclades\ttaxons\trank\ttaxid\tscientific name
+        100.00\t100\t100\tR\t1\troot
+        10.77\t100\t50\tS\t1337\t  Homo sapiens";
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(test_data.as_bytes()).unwrap();
+
+        let taxon_to_save = vec![1337];
+        let result = build_tree_from_kraken_report(&taxon_to_save, &file_path, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_process_kraken_report_invalid_first_line_not_header() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("kraken_report.txt");
+        let test_data = "\
+        BAD\tIAM ERRROR
+        100.00\t100\t100\tR\t1\troot";
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(test_data.as_bytes()).unwrap();
+
+        let taxon_to_save = vec![1];
+        let result = build_tree_from_kraken_report(&taxon_to_save, &file_path, true);
+        assert!(result.is_err());
+    }
+
     // report parsing tests
 
     #[test]
@@ -589,7 +672,7 @@ mod tests {
         let taxon_to_save = vec![1386, 1239];
         let ProcessedKrakenTree {
             nodes, taxon_map, ..
-        } = build_tree_from_kraken_report(&taxon_to_save, &file_path).unwrap();
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
         println!("{:?}", nodes);
         assert_eq!(nodes.len(), 11);
 
@@ -647,7 +730,7 @@ mod tests {
         let taxon_to_save = vec![1386, 1239];
         let ProcessedKrakenTree {
             nodes, taxon_map, ..
-        } = build_tree_from_kraken_report(&taxon_to_save, &file_path).unwrap();
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
         println!("{:?}", nodes);
         assert_eq!(nodes.len(), 10);
 
@@ -700,7 +783,7 @@ mod tests {
         let taxon_to_save = vec![1386, 1239, 0];
         let ProcessedKrakenTree {
             nodes, taxon_map, ..
-        } = build_tree_from_kraken_report(&taxon_to_save, &file_path).unwrap();
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
         println!("{:?}", nodes);
         assert_eq!(nodes.len(), 11);
 
@@ -727,7 +810,7 @@ mod tests {
             nodes,
             taxon_map,
             missing_taxon_ids: missing_taxons,
-        } = build_tree_from_kraken_report(&taxon_to_save, &file_path).unwrap();
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
         assert_eq!(nodes.len(), 4);
         assert_eq!(taxon_map.len(), 1);
         assert!(taxon_map.contains_key(&2));
@@ -750,7 +833,7 @@ mod tests {
             nodes,
             taxon_map,
             missing_taxon_ids: missing_taxons,
-        } = build_tree_from_kraken_report(&taxon_to_save, &file_path).unwrap();
+        } = build_tree_from_kraken_report(&taxon_to_save, &file_path, true).unwrap();
         assert_eq!(nodes.len(), 3);
         assert_eq!(taxon_map.len(), 0);
         assert_eq!(missing_taxons, vec![1386]);
@@ -760,7 +843,7 @@ mod tests {
     fn test_build_tree_from_kraken_report_file_not_found() {
         let nonexistent_path = PathBuf::from("nonexistent_file.txt");
         let taxon_to_save = vec![1386];
-        let result = build_tree_from_kraken_report(&taxon_to_save, &nonexistent_path);
+        let result = build_tree_from_kraken_report(&taxon_to_save, &nonexistent_path, true);
         assert!(result.is_err());
     }
 
@@ -776,7 +859,7 @@ mod tests {
         let mut file = File::create(&file_path).unwrap();
         file.write_all(test_data.as_bytes()).unwrap();
         let taxon_to_save = vec![131567];
-        let result = build_tree_from_kraken_report(&taxon_to_save, &file_path);
+        let result = build_tree_from_kraken_report(&taxon_to_save, &file_path, true);
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
Allows a kraken report to have a header line which will attempted to be skipped addresses #35 

Can be disabled with `--no-header-detect`

Also made error messages more informative with line number and line context